### PR TITLE
added text label

### DIFF
--- a/angular-progress-arc.js
+++ b/angular-progress-arc.js
@@ -38,6 +38,7 @@
                 stroke:           '@', // Color/appearance of stroke.
                 counterClockwise: '@', // Boolean value indicating
                 complete:         '&', // Expression evaluating to float [0.0, 1.0]
+                label:            '&', // Expression evaluating to string
                 background:       '@'  // Color of the background ring. Defaults to null.
             },
             compile: function (element, attr) {
@@ -78,6 +79,7 @@
                         'ng-attr-transform="rotate({{offset}}, {{size/2}}, {{size/2}})' +
                             '{{ (counterClockwise && counterClockwise != \'false\') ? \' translate(0, \' + size + \') scale(1, -1)\' : \'\' }}"' +
                         '/>' +
+                    '<text ng-if="label()" id="label" x="50%" y="50%" dy=".3em" text-anchor="middle">{{label()}}</text>' +
                 '</svg>'
         };
     }]);


### PR DESCRIPTION
Added a label in the middle of the progress arc to show a label, like a progress percentage or anything else that might be relative to the progression.

I don't know if you might find this useful for this component, but I needed it and I thought it might be useful to others as well.

I'm using it like in the following snippet:

```
<progress-arc ng-if="picture.file" label="picture.file.percentage | empty:'0%'" complete="picture.file.progress" counter-clockwise="true" background="#eee" class="progress-arc"></progress-arc>
```

Where `picture.file.percentage` and `picture.file.progress` get both updated during the upload and the `empty` filter just pushes the '0%' string until the first upload progress occurs.
